### PR TITLE
Changed 5 separate image fields to single 'Images' field

### DIFF
--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -50,29 +50,9 @@ Post.add({
     default: Date.now
   },
   publishedAt: Date,
-  img1: {
-    label: "Image1",
-    type: Types.CloudinaryImage,
-    autoCleanup: true
-  },
-  img2: {
-    label: "Image2",
-    type: Types.CloudinaryImage,
-    autoCleanup: true
-  },
-  img3: {
-    label: "Image3",
-    type: Types.CloudinaryImage,
-    autoCleanup: true
-  },
-  img4: {
-    label: "Image4",
-    type: Types.CloudinaryImage,
-    autoCleanup: true
-  },
-  img5: {
-    label: "Image5",
-    type: Types.CloudinaryImage,
+  imgs: {
+    label: "Images",
+    type: Types.CloudinaryImages,
     autoCleanup: true
   },
   content: {


### PR DESCRIPTION
This is related to [issue #416](https://github.com/uclaradio/uclaradio.com/issues/416) in the `uclaradio.com` repository.

With this field, instead of separately uploading five images, a user can upload an arbitrary number of images instead.